### PR TITLE
Feature/update after libopencm3 changes ref #2

### DIFF
--- a/dump-stm32/Makefile.include
+++ b/dump-stm32/Makefile.include
@@ -79,6 +79,9 @@ $(NAME).srec: $(NAME).elf
 $(NAME).list: $(NAME).elf
 	$(OBJDUMP) -S $(NAME).elf > $(NAME).list
 
+$(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a:
+	make -C $(TOOLCHAIN_DIR)
+
 $(NAME).elf: $(OBJS) $(LDSCRIPT) $(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a
 	$(LD) -o $(NAME).elf $(OBJS) -lopencm3_stm32f2 $(LDFLAGS)
 

--- a/dump-stm32/rng-test.ld
+++ b/dump-stm32/rng-test.ld
@@ -6,4 +6,4 @@ MEMORY
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
 }
 
-INCLUDE libopencm3_stm32f2.ld
+INCLUDE cortex-m-generic.ld


### PR DESCRIPTION
fixes #2
[This](https://github.com/trezor/rng-test/blob/229f60a3eb7b0082f7fda28ccc598957903d643a/dump-stm32/rng-test.ld#L9) looks as moved to [lib/cortex-m-generic.ld](https://github.com/libopencm3/libopencm3/blob/0fd4f74ee301af5de4e9b036f391bf17c5a52f02/lib/cortex-m-generic.ld) a year [ago](https://github.com/libopencm3/libopencm3/commit/9a05dcb6c0aef712052d337457838f6041ffd57a). 

Consider a rule like this:
```
$(TOOLCHAIN_DIR)/lib/libopencm3_stm32f2.a:
	make -C $(TOOLCHAIN_DIR)
```